### PR TITLE
use get_chained_prefix_path()

### DIFF
--- a/colcon_zsh/shell/template/prefix_chain.zsh.em
+++ b/colcon_zsh/shell/template/prefix_chain.zsh.em
@@ -16,10 +16,10 @@ _colcon_prefix_chain_zsh_source_script() {
     echo "not found: \"$1\"" 1>&2
   fi
 }
-@[if colcon_prefix_path]@
+@[if chained_prefix_path]@
 
 # source chained prefixes
-@[  for prefix in reversed(colcon_prefix_path)]@
+@[  for prefix in reversed(chained_prefix_path)]@
 # setting COLCON_CURRENT_PREFIX avoids determining the prefix in the sourced script
 COLCON_CURRENT_PREFIX="@(prefix)"
 _colcon_prefix_chain_zsh_source_script "$COLCON_CURRENT_PREFIX/@(prefix_script_no_ext).zsh"

--- a/colcon_zsh/shell/zsh.py
+++ b/colcon_zsh/shell/zsh.py
@@ -6,7 +6,7 @@ import sys
 
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
-from colcon_core.shell import get_colcon_prefix_path
+from colcon_core.prefix_path import get_chained_prefix_path
 from colcon_core.shell import logger
 from colcon_core.shell import ShellExtensionPoint
 from colcon_core.shell import use_all_shell_extensions
@@ -44,7 +44,8 @@ class ZShell(ShellExtensionPoint):
             Path(__file__).parent / 'template' / 'prefix_chain.zsh.em',
             prefix_chain_env_path,
             {
-                'colcon_prefix_path': get_colcon_prefix_path(skip=prefix_path),
+                'chained_prefix_path': get_chained_prefix_path(
+                    skip=prefix_path),
                 'prefix_script_no_ext': 'local_setup',
             })
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core>=0.3.0
+  colcon-core>=0.3.18
 packages = find:
 tests_require =
   flake8


### PR DESCRIPTION
Requires colcon/colcon-core#166.

Before being merged the minimum version dependency for `colcon-core` needs to be bumped.